### PR TITLE
Fix: "0" is converted to an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ---
 
+#### Unreleased
+
+##### Changed
+- The value `0` is not converted to an empty array when used in query parameters anymore
+
+---
+
 #### `[v0.1.8]` - 2019-01-29
 
 ##### Changed 

--- a/src/Query/QueryParamBag.php
+++ b/src/Query/QueryParamBag.php
@@ -74,6 +74,10 @@ class QueryParamBag
     private function prepareArrayBasedParams($value): void
     {
         collect($value)->each(function ($params, $field) {
+            if (is_array($params) === false && trim($params) === '') {
+                $params = [];
+            }
+
             if (is_array($params)) {
                 $params = $this->prepareArrayBasedNestedParams($params);
             }

--- a/src/Query/QueryParamBag.php
+++ b/src/Query/QueryParamBag.php
@@ -74,10 +74,6 @@ class QueryParamBag
     private function prepareArrayBasedParams($value): void
     {
         collect($value)->each(function ($params, $field) {
-            if (empty($params)) {
-                $params = [];
-            }
-
             if (is_array($params)) {
                 $params = $this->prepareArrayBasedNestedParams($params);
             }

--- a/tests/QueryParamBagTest.php
+++ b/tests/QueryParamBagTest.php
@@ -55,12 +55,20 @@ class QueryParamBagTest extends TestCase
 
     public function test_falsey_values_should_be_available(): void
     {
-        $url = '/url?filter[comments]=&filter[amount]=0&filter[verified]=false';
+        $url = '/url?filter[amount]=0&filter[verified]=false';
         $request = Request::create($url);
         $filterParam = new QueryParamBag($request, 'filter');
 
-        $this->assertSame('', $filterParam->get('comments'));
         $this->assertSame('0', $filterParam->get('amount'));
         $this->assertSame('false', $filterParam->get('verified'));
+    }
+
+    public function test_empty_values_default_to_empty_array(): void
+    {
+        $url = '/url?filter[comments]=';
+        $request = Request::create($url);
+        $filterParam = new QueryParamBag($request, 'filter');
+
+        $this->assertSame([], $filterParam->get('comments'));
     }
 }

--- a/tests/QueryParamBagTest.php
+++ b/tests/QueryParamBagTest.php
@@ -52,4 +52,15 @@ class QueryParamBagTest extends TestCase
         $this->assertFalse($filterParam->isEmpty('before'));
         $this->assertEquals($filterParam->get('before'), '21-02-2019');
     }
+
+    public function test_falsey_values_should_be_available(): void
+    {
+        $url = '/url?filter[comments]=&filter[amount]=0&filter[verified]=false';
+        $request = Request::create($url);
+        $filterParam = new QueryParamBag($request, 'filter');
+
+        $this->assertSame('', $filterParam->get('comments'));
+        $this->assertSame('0', $filterParam->get('amount'));
+        $this->assertSame('false', $filterParam->get('verified'));
+    }
 }


### PR DESCRIPTION
## Description

When a parameter is explicitely set to zero it is converted to an empty array, where it works correctly in laravel (illuminate/http):

```php
// ?filter[bar]=0
$request->filters()->get('bar');  // [] <= This should return 0
$request->input('filter.bar');    // "0"
```

## Motivation and context

It should be possible to set a value to the number zero explicitely. This PR fixes that so the following data is returned:

```php
// ?filter[bar]=0
$request->filters()->get('bar');  // "0"
```

## How has this been tested?

This has been manually tested in the project we experience this issue in. Also test cases are included in this PR.

## Screenshots (if appropriate)

N/A

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
